### PR TITLE
fix: setting samesite attribute for cookies

### DIFF
--- a/backend/src/controllers/users.ts
+++ b/backend/src/controllers/users.ts
@@ -171,9 +171,11 @@ async function logInWithAuthCode(req: Request, res: Response) {
   const email: string = req.body.email;
   const jwtToken = UserAuthService.issueJwtForUser(email);
   res.cookie('authentication_token', jwtToken, {
-    httpOnly: true,
+    httpOnly: true, // JavaScript code in frontend won't have access to this cookie
     maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days in milliseconds
     path: '/',
+    sameSite: 'none', //specify it as "None" as the cookie needs to be sent in a cross-origin context
+    secure: true, // use https to send
   });
   res.sendStatus(200);
 }


### PR DESCRIPTION
## Description
related to the SameSite attribute for cookies, which is a security feature that helps protect against certain types of attacks, such as Cross-Site Request Forgery (CSRF). By default, if a cookie doesn't specify a SameSite attribute, it defaults to "SameSite=Lax."
## Related Issue(s)
no
## How Has This Been Tested?

- [x] Visually
- [ ] Unit
- [ ] Integration

## Types of changes

- [x] Bug fix (fix)
- [ ] New feature (feat)
- [ ] Improvement/refactoring (refactor)
- [ ] Code style (style)
- [ ] Build (build):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

- [x] The PR title is filled in correctly.
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`main`).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation
